### PR TITLE
feat: Implement SweetAlert2 confirmation for task deletion

### DIFF
--- a/myproject/users/forms.py
+++ b/myproject/users/forms.py
@@ -59,6 +59,14 @@ class TodoForm(forms.ModelForm):
             # Provide a default for time_spent_hours if no instance or time_spent is None
             self.initial['time_spent_hours'] = self.fields['time_spent_hours'].initial if self.fields['time_spent_hours'].initial is not None else 0
 
+        # Make status not required in the form, model default will be used
+        self.fields['status'].required = False
+        # Set initial for status if it's a new form and status is not already in initial data
+        # This helps the form display the default value even before saving.
+        if not self.initial.get('status') and not (self.instance and self.instance.pk):
+            self.initial['status'] = 'todo' # Corresponds to model default
+
+
     def clean_time_spent_hours(self):
         hours = self.cleaned_data.get('time_spent_hours')
         if hours is None:

--- a/myproject/users/templates/todo/base.html
+++ b/myproject/users/templates/todo/base.html
@@ -10,6 +10,8 @@
     <!-- Font Awesome CSS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <link rel="stylesheet" href="{% static 'css/custom.css' %}">
+    <!-- SweetAlert2 CSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
 </head>
 <body class="d-flex flex-column h-100">
 
@@ -126,5 +128,7 @@
 
 <!-- Add Bootstrap and other JS files here, if needed -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<!-- SweetAlert2 JS -->
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </body>
 </html>

--- a/myproject/users/templates/todo/todo_list.html
+++ b/myproject/users/templates/todo/todo_list.html
@@ -113,7 +113,7 @@
             <td>
                 <button type="button" class="btn btn-sm btn-outline-primary me-1 inline-edit-btn">Inline Edit</button>
                 <a href="{% url 'edit_todo' todo.id %}" class="btn btn-sm btn-outline-secondary">Edit Page</a>
-                <a href="{% url 'delete_todo' todo.id %}" class="btn btn-sm btn-danger" >Delete</a>
+                <button class="btn btn-sm btn-danger delete-todo-btn" data-todo-id="{{ todo.id }}" data-delete-url="{% url 'delete_todo' todo.id %}">Delete</button>
             </td>
         </tr>
         {% empty %}
@@ -323,17 +323,76 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // --- End Create Task Modal Logic ---
 
-
+    // Combined event listener for table body
     tableBody.addEventListener('click', function (event) {
         const target = event.target;
         const row = target.closest('tr');
-        if (!row || !row.dataset.id) return; // Not a relevant click or row
 
+        if (!row || !row.dataset.id) { // Check if click is on a valid row
+             // Handle delete button click specifically, as it might be the only button on the row
+            if (target.classList.contains('delete-todo-btn')) {
+                event.preventDefault();
+                const todoId = target.dataset.todoId;
+                const deleteUrl = target.dataset.deleteUrl;
+                const specificRowToRemove = target.closest('tr'); // a more specific row for removal
+
+                Swal.fire({
+                    title: 'Are you sure?',
+                    text: "You won't be able to revert this!",
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonColor: '#d33',
+                    cancelButtonColor: '#3085d6',
+                    confirmButtonText: 'Yes, delete it!'
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        fetch(deleteUrl, {
+                            method: 'POST',
+                            headers: {
+                                'X-CSRFToken': csrfToken, // Defined above
+                                'X-Requested-With': 'XMLHttpRequest'
+                            }
+                        })
+                        .then(response => {
+                            if (!response.ok) {
+                                return response.json().then(err => { throw err; });
+                            }
+                            return response.json();
+                        })
+                        .then(data => {
+                            if (data.success) {
+                                if (specificRowToRemove) specificRowToRemove.remove();
+                                Swal.fire('Deleted!','Your task has been deleted.','success');
+                                if (tableBody.querySelectorAll('tr').length === 0) {
+                                    const emptyMessageHtml = `
+                                        <tr>
+                                            <td colspan="6" class="text-center text-muted">
+                                                You have no tasks yet. <a href="{% url 'add_todo' %}">Add one!</a>
+                                            </td>
+                                        </tr>`;
+                                    tableBody.innerHTML = emptyMessageHtml;
+                                }
+                            } else {
+                                Swal.fire('Failed!', data.error || 'Could not delete the task.', 'error');
+                            }
+                        })
+                        .catch(error => {
+                            console.error('Error deleting task:', error);
+                            Swal.fire('Error!', error.error || 'An unexpected error occurred.', 'error');
+                        });
+                    }
+                });
+            } // End of delete button logic
+            return; // If not on a valid row and not delete button, do nothing
+        }
+
+
+        // If we are on a valid row (row && row.dataset.id is true)
         const todoId = row.dataset.id;
 
         // Handle "Inline Edit" button click
         if (target.classList.contains('inline-edit-btn')) {
-            if (row.classList.contains('editing')) return; // Already editing this row
+            if (row.classList.contains('editing')) return; // Already editing
             enterEditMode(row, target);
         }
         // Handle "Save" button click
@@ -343,6 +402,54 @@ document.addEventListener('DOMContentLoaded', function () {
         // Handle "Cancel" button click
         else if (target.classList.contains('cancel-btn')) {
             cancelEditMode(row);
+        }
+        // Handle "Delete" button click (if missed by the above specific check, e.g. if row.dataset.id was initially null but button is valid)
+        // This is a fallback, the primary check for delete is above.
+        else if (target.classList.contains('delete-todo-btn')) {
+             event.preventDefault();
+            const deleteUrl = target.dataset.deleteUrl;
+            // const specificRowToRemove = target.closest('tr'); // Already have 'row'
+
+            Swal.fire({
+                title: 'Are you sure?',
+                text: "You won't be able to revert this!",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                cancelButtonColor: '#3085d6',
+                confirmButtonText: 'Yes, delete it!'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    fetch(deleteUrl, {
+                        method: 'POST',
+                        headers: {
+                            'X-CSRFToken': csrfToken,
+                            'X-Requested-With': 'XMLHttpRequest'
+                        }
+                    })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.success) {
+                            if (row) row.remove(); // Use current row
+                            Swal.fire('Deleted!','Your task has been deleted.','success');
+                             if (tableBody.querySelectorAll('tr').length === 0) {
+                                const emptyMessageHtml = `
+                                    <tr>
+                                        <td colspan="6" class="text-center text-muted">
+                                            You have no tasks yet. <a href="{% url 'add_todo' %}">Add one!</a>
+                                        </td>
+                                    </tr>`;
+                                tableBody.innerHTML = emptyMessageHtml;
+                            }
+                        } else {
+                            Swal.fire('Failed!', data.error || 'Could not delete the task.', 'error');
+                        }
+                    })
+                    .catch(error => {
+                        Swal.fire('Error!', 'An unexpected error occurred.', 'error');
+                    });
+                }
+            });
         }
     });
 

--- a/myproject/users/views.py
+++ b/myproject/users/views.py
@@ -139,10 +139,19 @@ def add_todo(request):
 @login_required
 def delete_todo(request, todo_id):
     todo = get_object_or_404(TodoItem, id=todo_id, user=request.user)
+    is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+
     if request.method == 'POST':
         todo.delete()
-        return redirect('todo_list')
+        if is_ajax:
+            return JsonResponse({'success': True})
+        else:
+            # Fallback for non-AJAX POST, though primarily expecting AJAX now
+            return redirect('todo_list')
 
+    # For GET requests, or if not POST (though delete should be POST)
+    # This part will be less used if all deletes are via AJAX on the list page.
+    # If a user somehow navigates to the delete URL directly via GET.
     return render(request, 'todo/delete_todo.html', {'todo': todo})
 
 # @login_required


### PR DESCRIPTION
Integrates SweetAlert2 to provide a user-friendly confirmation dialog when deleting a task from the todo list.

Key changes:
- Added SweetAlert2 library to base template.
- Modified todo_list.html:
    - Changed delete link to a button.
    - Added JavaScript to trigger SweetAlert2 confirmation.
    - On confirmation, an AJAX POST request is sent to the delete URL.
    - The task row is removed from the table on successful AJAX response.
- Updated delete_todo view in views.py:
    - Handles AJAX POST requests by returning JsonResponse.
    - Retains existing behavior for non-AJAX requests as a fallback.
- Fixed failing TodoFormTests by making the 'status' field not required in TodoForm, allowing the model's default to be used.