### PR TITLE
Style Kanban new task form project dropdown

### DIFF
--- a/myproject/users/static/css/kanban.css
+++ b/myproject/users/static/css/kanban.css
@@ -196,7 +196,8 @@ body {
 }
 
 .new-task-form input[type="text"],
-.new-task-form textarea {
+.new-task-form textarea,
+.new-task-form select { /* Added select for project dropdown */
     width: 100%;
     margin-bottom: 8px;
     padding: 8px;
@@ -207,7 +208,8 @@ body {
     color: #172b4d;
 }
 .new-task-form input[type="text"]:focus,
-.new-task-form textarea:focus {
+.new-task-form textarea:focus,
+.new-task-form select:focus { /* Added select focus */
     border-color: #0052cc; /* Jira's blue focus color */
     box-shadow: 0 0 0 1px #0052cc; /* Focus ring */
     outline: none;

--- a/myproject/users/views.py
+++ b/myproject/users/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import login
 from .forms import CustomUserCreationForm, CustomAuthenticationForm
 from django.contrib.auth.decorators import login_required
-from .models import TodoItem, UserProfile, Project
+from .models import TodoItem, UserProfile
 from .forms import TodoForm
 from django.db.models import Sum, Q
 from django.urls import reverse
@@ -32,7 +32,7 @@ def user_login(request):
         form = CustomAuthenticationForm()
     return render(request, 'registration/login.html', {'form': form})
 
-# Removed redundant import of Project
+from .models import Project # Make sure Project is imported
 
 @login_required
 def todo_list(request):


### PR DESCRIPTION
Updated kanban.css to ensure the project select dropdown in the new task creation form on the Kanban board has consistent styling with other input fields in that form.